### PR TITLE
Update BNA REST API client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,7 +792,7 @@ dependencies = [
 [[package]]
 name = "bnaclient"
 version = "1.0.0"
-source = "git+https://github.com/PeopleForBikes/bna-api?rev=1b40300#1b4030044b807d8a8bf1540b5dae976051a24d28"
+source = "git+https://github.com/PeopleForBikes/bna-api?rev=9c2ce02#9c2ce022bb76863666a51446eef92a10ab524303"
 dependencies = [
  "bytes",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,7 @@ aws-sdk-s3 = "1.65.0"
 aws-sdk-sqs = "1.50.0"
 aws-smithy-types-convert = "0.60.8"
 axum = "0.7.7"
-bnaclient = { git = "https://github.com/PeopleForBikes/bna-api", rev = "1b40300" }
-# bnaclient = { path = "/Users/rgreinhofer/projects/PeopleForBikes/bna-api/bnaclient" }
+bnaclient = { git = "https://github.com/PeopleForBikes/bna-api", rev = "9c2ce02" }
 bnacore = { git = "https://github.com/PeopleForBikes/brokenspoke", rev = "c20ec31" }
 chrono = "0.4.19"
 clap = "4.5.20"


### PR DESCRIPTION
Updates the BNA REST API client to the current version.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
