### PR TITLE
Fix missing pipeline values

### DIFF
--- a/lambdas/src/bna-fargate-run.rs
+++ b/lambdas/src/bna-fargate-run.rs
@@ -54,7 +54,8 @@ async fn function_handler(event: LambdaEvent<TaskInput>) -> Result<TaskOutput, E
                 .state_machine_id(StateMachineId(state_machine_id))
                 .start_time(Utc::now())
                 .step(Step::Setup)
-                .sqs_message(serde_json::to_string(analysis_parameters)?),
+                .sqs_message(serde_json::to_string(analysis_parameters)?)
+                .s3_bucket(aws_s3.destination.clone()),
         )
         .send()
         .await?;


### PR DESCRIPTION
The BNA Pipeline database entries were missing some information, and
store a run cost always equal to zero.

This patch addresses these issues.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
