### PR TITLE
Fix Fargate price per second

### DIFF
--- a/lambdas/src/bna-save-results.rs
+++ b/lambdas/src/bna-save-results.rs
@@ -19,7 +19,7 @@ use tracing::info;
 use uuid::Uuid;
 
 const OVERALL_SCORES_COUNT: usize = 23;
-const FARGATE_COST_PER_SEC: Decimal = dec!(0.00228333333333);
+const FARGATE_COST_PER_SEC: Decimal = dec!(0.000038);
 
 #[derive(Deserialize)]
 struct TaskInput {
@@ -615,10 +615,7 @@ mod tests {
 
         let fargate_time = FargateTime::new(started_at, stopped_at);
         assert_eq!(fargate_time.elapsed(), 10);
-        assert_eq!(
-            fargate_time.cost(FARGATE_COST_PER_SEC),
-            dec!(0.0228333333333)
-        );
+        assert_eq!(fargate_time.cost(FARGATE_COST_PER_SEC), dec!(0.000380));
     }
 
     // #[tokio::test]


### PR DESCRIPTION
The current Fargate price per second value was actually the value of the
price per minute, making it 60 times more expensice than it actually
was!

The price per second was updated with the correct value.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
